### PR TITLE
update raz test after raz update

### DIFF
--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -236,9 +236,11 @@ impl Edit<List<usize>,usize> for EditorOopsla2015Sec2 {
 impl<S> Generate<RazTree<usize>> for UniformInsert<RazTree<usize>, S> {
   fn generate<R:Rng> (rng:&mut R, params:&GenerateParams) -> RazTree<usize> {
     let mut r = Raz::new();
+    let mut n = 0;
     for i in 0..params.size {
       if i % params.gauge == 0 {
-        r.archive_left( gen_level(rng) );
+        r.archive_left( gen_level(rng),  Some(name_of_usize(n)));
+        n += 1;
       } else { } ;
       // use random data (numbers 1000-1999 )
       // r.push_left( rng.gen::<usize>() % 1000 + 1000 );
@@ -256,17 +258,19 @@ impl Edit<RazTree<usize>, usize> for UniformInsert<RazTree<usize>, usize> {
   fn edit<R:Rng>(tree:RazTree<usize>, i:usize,
                  rng:&mut R, _params:&GenerateParams) -> (RazTree<usize>, usize) {
     let t = tree;
+    let mut n = i;
     let pos = rng.gen::<usize>() % ( i + 1 );
     let mut r = t.focus( pos ).unwrap();
     if i % _params.gauge == 0 {
-      r.archive_left( gen_level(rng) );
+      r.archive_left( gen_level(rng), Some(name_of_usize(n)) );
+      n += 1;
     } else { } ;
     // use random data (numbers 1000-1999 )
     // r.push_left( rng.gen::<usize>() % 1000 + 1000 );
     // use the insertion count, marked by adding a million
     r.push_left( i + 1_000_000 );
     let t = r.unfocus();    
-    (t, i + 1)
+    (t, n)
   }
 }
 
@@ -539,7 +543,7 @@ impl Compute<List<Pt2D>,List<Pt2D>> for Quickhull {
 
 impl Compute<RazTree<usize>,usize> for RazMax {
   fn compute(inp:RazTree<usize>) -> usize {
-    let max = inp.fold_up(|e|*e,|e1,e2|::std::cmp::max(e1,e2));
+    let max = inp.fold_up(Rc::new(|e:&usize|*e),Rc::new(|e1:usize,e2:usize|::std::cmp::max(e1,e2)));
     max.unwrap_or(0)
   }
 }

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -258,19 +258,17 @@ impl Edit<RazTree<usize>, usize> for UniformInsert<RazTree<usize>, usize> {
   fn edit<R:Rng>(tree:RazTree<usize>, i:usize,
                  rng:&mut R, _params:&GenerateParams) -> (RazTree<usize>, usize) {
     let t = tree;
-    let mut n = i;
     let pos = rng.gen::<usize>() % ( i + 1 );
     let mut r = t.focus( pos ).unwrap();
     if i % _params.gauge == 0 {
-      r.archive_left( gen_level(rng), Some(name_of_usize(n)) );
-      n += 1;
+      r.archive_left( gen_level(rng), Some(name_of_usize(i)) );
     } else { } ;
     // use random data (numbers 1000-1999 )
     // r.push_left( rng.gen::<usize>() % 1000 + 1000 );
     // use the insertion count, marked by adding a million
     r.push_left( i + 1_000_000 );
     let t = r.unfocus();    
-    (t, n)
+    (t, i+1)
   }
 }
 


### PR DESCRIPTION
added names to `archive()` and `Rc`'s to `fold_up` closures. The `Rc<Closure>` seems to require types in the parameters.

Fold_up is now `fold_up(self,...)` rather than `&self`. No change was needed in this simple test code.
